### PR TITLE
Update eFa-Backup with eFa-Version

### DIFF
--- a/rpmbuild/SOURCES/eFa-5.0.0/eFa/eFa-Backup
+++ b/rpmbuild/SOURCES/eFa-5.0.0/eFa/eFa-Backup
@@ -1,9 +1,9 @@
 #!/bin/bash
 # +--------------------------------------------------------------------+
 # eFa Backup
-# Version 20230312
+# Version 20240630
 # +--------------------------------------------------------------------+
-# Copyright (C) 2012~2023  http://www.efa-project.org
+# Copyright (C) 2012~2024  http://www.efa-project.org
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -109,6 +109,7 @@ function start_backup()
   cp -a /etc/sudo.conf $WORKINGDIR/etc
   mkdir -p $WORKINGDIR/etc/sudoers.d
   cp -a /etc/sudoers.d/* $WORKINGDIR/etc/sudoers.d
+  cp -a /etc/eFa-Version $WORKINGDIR/etc
 
   # Backup MailScanner settings
   mkdir -p $WORKINGDIR/etc/MailScanner


### PR DESCRIPTION
Include current eFa Version: /etc/eFa-Version

Next step would be to compare installed version against the backup with a "Force Restore" or "Quit" option if not a match, or where restoring cross-versions is permitted. I.e. 4.4 to 5.0, but not 4.4 to 5.1?